### PR TITLE
Set settings.py up for DB deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .github/
 cloudinary_python.txt
 *.sqlite3
+.venv/

--- a/axisofaccessproject/settings.py
+++ b/axisofaccessproject/settings.py
@@ -10,7 +10,14 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
+import os
+import dj_database_url
 from pathlib import Path
+
+# Load env variables from env.py if it exists
+env_path = Path(__file__).resolve().parent / 'env.py'
+if env_path.exists():
+    exec(open(env_path).read())
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -25,7 +32,7 @@ SECRET_KEY = 'django-insecure-&#aw$zs5&29xklsvd9dio0--xe&emuo_n)vlb(*qf=*((b2)8p
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['8000-aslinedvins-axisofacces-wds6t2evct2.ws-eu116.gitpod.io']
+ALLOWED_HOSTS = ['127.0.0.1', '8000-aslinedvins-axisofacces-wds6t2evct2.ws-eu116.gitpod.io']
 
 
 # Application definition
@@ -76,13 +83,17 @@ WSGI_APPLICATION = 'axisofaccessproject.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+if 'DATABASE_URL' in os.environ:
+    DATABASES = {
+        'default': dj_database_url.parse(os.environ.get('DATABASE_URL'))
     }
-}
-
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
+    }
 
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
Sets settings.py to use local sqlite if working locally, and to use the env variable DATABASE_URL if it exists, which it will need to be set once deployed to Heroku. I just realized I forgot to also update requirements.txt so I will do another commit